### PR TITLE
feat: add `ERC20Metadata`

### DIFF
--- a/contracts/tokens/ERC20Metadata.sol
+++ b/contracts/tokens/ERC20Metadata.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2024.
+pragma solidity ^0.8.17;
+
+/// @title ERC20Metadata
+contract ERC20Metadata {
+    string public name;
+    string public symbol;
+    uint8 public immutable decimals;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) {
+        name = name_;
+        symbol = symbol_;
+        decimals = decimals_;
+    }
+}


### PR DESCRIPTION
This "token-like" contract can serve as a dummy key in the price oracle to register /ETH price feeds